### PR TITLE
La log4j appender

### DIFF
--- a/common/components/org.wso2.carbon.data.agents.log4j/src/main/java/org/wso2/carbon/data/agents/log4j/appender/LogEventAppender.java
+++ b/common/components/org.wso2.carbon.data.agents.log4j/src/main/java/org/wso2/carbon/data/agents/log4j/appender/LogEventAppender.java
@@ -110,7 +110,9 @@ public class LogEventAppender extends AppenderSkeleton implements Appender {
 
     public void close() {
         try {
-            dataPublisher.shutdown();
+            if(dataPublisher!=null){
+                dataPublisher.shutdown();
+            }
         } catch (DataEndpointException e) {
             log.error("Error in shutting down the data publisher " + e.getMessage(), e);
         }


### PR DESCRIPTION
This fix is for avoiding the consecutive data publisher initialization issue.
Upadate appender close method by data publisher shutdown if it is not null.
